### PR TITLE
Fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/bluecitylights/sbotify/security/code-scanning/8](https://github.com/bluecitylights/sbotify/security/code-scanning/8)

The best way to fix the problem is to explicitly declare the required `permissions` at either the root of the workflow or at the job level, limiting them to the least privilege. In this case, since the job and workflow do not interact with the repository in a way that requires write access (it only checks out code, sets up Python, installs dependencies, and runs tests), `contents: read` is likely sufficient. The preferred place to include the `permissions` key is at the top (root level, after the `name`), thereby establishing the permissions for all jobs in the workflow. No other changes to the logic or steps are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
