### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -24,6 +24,8 @@ on:
       APP:
         required: true
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/chat-ci-cd.yml
+++ b/.github/workflows/chat-ci-cd.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Print folder-changed
         run: echo "folder-changed = ${{ needs.check-changes.outputs.folder-changed }}"
   check-changes:
+    permissions:
+      contents: read
     uses: ./.github/workflows/check-changes.yml
     with:
       folder: chat

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy
+permissions:
+  contents: read
 
 on:
   workflow_call:

--- a/.github/workflows/mcp-server-ci-cd.yml
+++ b/.github/workflows/mcp-server-ci-cd.yml
@@ -13,10 +13,11 @@ on:
 
 jobs:
   check-changes:
+    permissions:
+      contents: read
     uses: ./.github/workflows/check-changes.yml
     with:
       folder: mcp-server
-
   call-base:
     needs: check-changes
     if: needs.check-changes.outputs.folder-changed == 'true'


### PR DESCRIPTION
Potential fix for [https://github.com/bluecitylights/sbotify/security/code-scanning/7](https://github.com/bluecitylights/sbotify/security/code-scanning/7)

To address the problem, you should add an explicit `permissions` key to the workflow or to the relevant job(s). The recommended approach is to set this key at the root of the workflow file, so the permissions apply globally to all jobs not otherwise configured. In this workflow, only basic `contents: read` permissions are necessary; there is no evidence in the steps of needing broader write permissions. The best practice is to add the `permissions` block just after the `name` block, typically before or after the `on:` block. No additional imports, methods, or complex changes are required—just insertion of the relevant YAML lines.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
